### PR TITLE
Fix link to Eleventy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and not a replacement for CSSWG issue threads**.
 ## Development Scripts
 
 This static site is built using
-[Eleventy](11ty.dev/),
+[Eleventy](https://11ty.dev/),
 based on a [skeleton template](https://11ty.rocks/)
 developed by [@5t3ph](https://twitter.com/5t3ph).
 


### PR DESCRIPTION
The current link links to https://github.com/oddbird/css-sandbox/blob/main/11ty.dev when the README is accessed by browsing GitHub.