### PR TITLE
Fix typo

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -6,7 +6,7 @@ Maintained by
 Subscribe to the [feed of changes](/feed.xml).
 
 [Edit this page]({{ [github.files, page.inputPath] | join }}),
-[wiew page history]({{ [github.history, page.inputPath] | join }}),
+[view page history]({{ [github.history, page.inputPath] | join }}),
 or
 [file an issue]({{ github.issues }})
 on GitHub


### PR DESCRIPTION
Hi! I noticed a typo in the footer, this fixes it

!["cute cat"](https://source.unsplash.com/featured/?cute,animal&cat)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


